### PR TITLE
fixed self-closing div tag

### DIFF
--- a/xs3p.xsl
+++ b/xs3p.xsl
@@ -2564,7 +2564,7 @@ pre {
                   <xsl:value-of select="text()"/>
                   <xsl:if test="./@source">
                      Linked documentation: <xsl:value-of select="./@source"/>
-                  </xsl:if>
+                  </xsl:if><xsl:text> </xsl:text>
                </div>
                <div class="xs3p-doc" id="{generate-id(.)}{$suffix}-doc"><xsl:text> </xsl:text></div>
             </div>


### PR DESCRIPTION
fixes a self-closing div tag (appears if there is no text in a document-tag), which is not allowed in HTML